### PR TITLE
adding romannumeral route to the express route

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "index.js",
   "scripts": {
     "serve": "npm run build && npm run start",
-    "build": "npm run test && tsc",
-    "start": "node dist/index.js",
+    "build": "rm -rf dist/* && npm run test && tsc",
+    "start": "node dist/src/index.js",
     "test": "jest"
   },
   "keywords": [],

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -1,0 +1,1 @@
+export const PORT = 8000;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,11 @@
-import express, { Express, Request, Response} from 'express';
+import express, { Express } from 'express';
+import { romanNumberRouter } from './routes/romanNumeralRoutes';
+import { PORT } from './config/config';
 
 const app: Express = express();
-const port = 8000;
 
-app.get('/', (req: Request, res: Response) => {
-    res.send('Hello from express TS');
+app.use('/romannumeral', romanNumberRouter);
+
+app.listen(PORT, () => {
+    console.log(`port listening on ${PORT}`);
 });
-
-app.listen(port, () => {
-    console.log(`port listening on ${port}`);
-})

--- a/src/routes/romanNumeralRoutes.ts
+++ b/src/routes/romanNumeralRoutes.ts
@@ -1,0 +1,7 @@
+import express, { Request, Response} from 'express';
+
+export const romanNumberRouter = express.Router();
+
+romanNumberRouter.get("/", (req: Request, res: Response) => {
+    res.send("Hello from route!");
+});


### PR DESCRIPTION
### What is in this PR?

- Created a routes folder to separate the routes for future extensibility (when we decide to add other routes)
- Added `romanNumeralRoutes.ts` which defines the routes after the path `romannumeral`

### Testing
- manually tested the route is working find with `localhost:8000/romannumeral`
- build was successful and all the unit tests passed.