### PR TITLE
adding docker compose and prometheus container for metric collections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.2'
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+    - 9090:9090
+    command:
+    - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+    - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    depends_on:
+    - romannumeral
+  romannumeral:
+    build: .
+    container_name: romannumeral-service
+    ports:
+    - 8000:8000

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,6 @@
+scrape_configs:
+- job_name: cadvisor
+  scrape_interval: 5s
+  static_configs:
+  - targets:
+    - cadvisor:8080


### PR DESCRIPTION
### What is in this PR?

- Adding prometheus monitoring tool, which will be used to collect service level metrics
- Adding a docker compose file so that we can run both the application web server and prometheus server at once.

https://prometheus.io/

### Testing
- Manually tested the command `docker compose up` and was able to visit the Prometheus server in `localhost:9090`
- Build was successful